### PR TITLE
fix (gulpfile): update and fix watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -164,17 +164,18 @@ gulp.task('browserSync', function () {
 
 // watch task
 gulp.task('watch', function () {
-    // plugins.watch(config.src.html, function () {
-    //     plugins.sequence('compile', function() {
-    //         bsreload();
-    //     });
-    // });
+    plugins.watch([config.src.pages, config.src.includes, config.src.data], function () {
+        plugins.sequence('compile:templates', function() {
+            bsreload();
+        });
+    });
+
     plugins.watch(config.src.styles, function () {
-        gulp.start('styles:app')
+        gulp.start('styles')
     });
 
     plugins.watch(config.src.images, function () {
-        gulp.start('images:app')
+        gulp.start('images')
     });
 });
 


### PR DESCRIPTION
1. Updated the gulp watch task to watch template and data files

2. Fixed the gulp task references for the 'styles' and 'images' tasks ('styles:app' and 'images:app' tasks do not exist)