### PR TITLE
Use MozJPEG on production builds

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,6 +7,9 @@ var srcAssetsDir = srcDir + '/public';
 var destDir = 'site';
 var destAssetsDir = destDir + '/public';
 
+// modules
+var imageminMozjpeg = require('imagemin-mozjpeg');
+
 module.exports = {
 
   dev: true, // gutil.env.dev
@@ -44,6 +47,12 @@ module.exports = {
           { removeViewBox: false },               // 3a
           { removeUselessStrokeAndFill: false },  // 3b
           { removeEmptyAttrs: false }             // 3c
+      ],
+      use: [
+        imageminMozjpeg({
+          progressive: true,
+          quality: 80
+        })
       ]
   },
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
     "gulp-watch": "^4.3.3",
+    "imagemin-mozjpeg": "^5.1.0",
     "lodash": "^3.10.0",
     "merge-stream": "^1.0.0",
     "q": "^1.4.1",


### PR DESCRIPTION
MozJPEG is a JPEG encoder which, on average, has a [2% advantage over Jpegtran](http://calendar.perfplanet.com/2015/upgrading-jpegtran-to-mozjpeg/), Imagemin's built-in encoder.

A test on the Sidley redesign resulted in a nice gain:

<img width="782" alt="sidley" src="https://cloud.githubusercontent.com/assets/10171306/12661213/dbb9e158-c5dd-11e5-9bbc-98da2d0db67a.png">
